### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.2](https://github.com/lilith-roth/web-dump-rs/compare/v0.1.1...v0.1.2) - 2025-04-05
+
+### Other
+
+- fix missing dependencies on binary release ([#5](https://github.com/lilith-roth/web-dump-rs/pull/5))
+
 ## [0.1.1](https://github.com/lilith-roth/web-dump-rs/compare/v0.1.0...v0.1.1) - 2025-04-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "web-dump-rs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "web-dump-rs"
 description = "Application to retrieve all files from a web server based on a provided wordlist."
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/web-dump-rs/"


### PR DESCRIPTION



## 🤖 New release

* `web-dump-rs`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/lilith-roth/web-dump-rs/compare/v0.1.1...v0.1.2) - 2025-04-05

### Other

- fix missing dependencies on binary release ([#5](https://github.com/lilith-roth/web-dump-rs/pull/5))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).