### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1](https://github.com/lilith-roth/web-dump-rs/compare/v0.2.0...v0.2.1) - 2025-04-14
+
+### Other
+
+- readme update ([#25](https://github.com/lilith-roth/web-dump-rs/pull/25))
+
 ## [0.1.8](https://github.com/lilith-roth/web-dump-rs/compare/v0.1.7...v0.1.8) - 2025-04-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "web-dump-rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "web-dump-rs"
 description = "Application to retrieve all files from a web server based on a provided wordlist."
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/web-dump-rs/"


### PR DESCRIPTION



## 🤖 New release

* `web-dump-rs`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/lilith-roth/web-dump-rs/compare/v0.2.0...v0.2.1) - 2025-04-14

### Other

- readme update ([#25](https://github.com/lilith-roth/web-dump-rs/pull/25))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).