### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.2](https://github.com/lilith-roth/web-dump-rs/compare/v0.3.1...v0.3.2) - 2025-04-30
+
+### Other
+
+- added config file for release-plz
+
 ## [0.3.1](https://github.com/lilith-roth/web-dump-rs/compare/v0.3.0...v0.3.1) - 2025-04-30
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "web-dump-rs"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "web-dump-rs"
 description = "Application to retrieve all files from a web server based on a provided wordlist."
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/lilith-roth/web-dump-rs/"


### PR DESCRIPTION



## 🤖 New release

* `web-dump-rs`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/lilith-roth/web-dump-rs/compare/v0.3.1...v0.3.2) - 2025-04-30

### Other

- added config file for release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).